### PR TITLE
Add "A.I." turn limitation

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -70,15 +70,15 @@ const cellsHard = [
 const suite = new Benchmark.Suite;
 
 suite.add('findWord#3x3', function () {
-  ai.findWord(cells3);
+  ai.findWord(cells3, 10);
 }).add('findWord#4x4', function () {
-  ai.findWord(cells4);
+  ai.findWord(cells4, 10);
 }).add('findWord#5x5', function () {
-  ai.findWord(cells5);
+  ai.findWord(cells5, 10);
 }).add('findWord#complex', function () {
-  ai.findWord(cellsComplex);
+  ai.findWord(cellsComplex, 10);
 }).add('findWord#hard', function () {
-  ai.findWord(cellsHard);
+  ai.findWord(cellsHard, 10);
 }).on('cycle', function (event) {
   console.log(String(event.target));
 }).run({ 'async': true });
@@ -106,7 +106,7 @@ suite.add('findWord#3x3', function () {
 
 //--- entryPoint: 4758.724ms
 
-// console.log('--findWord', ai.findWord(cellsHard));
+// console.log('--findWord', ai.findWord(cellsHard, 10));
 
 // get the most long words from vocabulary
 // console.log([...vocabulary.words].sort((a, b) => b.length - a.length).slice(0, 100).map(w => [w, w.length]));

--- a/lib/AI.js
+++ b/lib/AI.js
@@ -22,7 +22,9 @@ export default class AI {
     this._vocabulary = vocabulary;
   }
 
-  findWord(cells, usedWords = []) {
+  findWord(cells, turnLimitSec, usedWords = []) {
+    const t0 = Date.now(); // there is no performance.now() in React Native
+    const turnLimitMS = turnLimitSec * 1000;
     const prefixes = this._vocabulary.prefixes;
     const characters = this._vocabulary.characters;
 
@@ -33,15 +35,20 @@ export default class AI {
       const paths = this._optimizePathsBack(graph.paths, prefixes);
 
       characters.forEach((char) => {
-        const filledPaths = this._fillPaths(paths, char);
-        const optimizedPaths = this._optimizePathsFront(filledPaths, prefixes);
-        const possibleChains = this._generateChains(optimizedPaths);
+        const tChar = Date.now();
 
-        wordsVariants[[char, idx]] = {
-          index: idx,
-          character: char,
-          words: this._findWords(possibleChains, usedWords)
-        };
+        // skip character if it takes too long already
+        if (tChar - t0 < turnLimitMS) {
+          const filledPaths = this._fillPaths(paths, char);
+          const optimizedPaths = this._optimizePathsFront(filledPaths, prefixes);
+          const possibleChains = this._generateChains(optimizedPaths);
+
+          wordsVariants[[char, idx]] = {
+            index: idx,
+            character: char,
+            words: this._findWords(possibleChains, usedWords)
+          };
+        }
       });
     });
 

--- a/screens/SettingsScreen.js
+++ b/screens/SettingsScreen.js
@@ -19,11 +19,13 @@ const SettingsScreen = inject('GameStore')(observer(class SettingsScreen extends
     maxFieldSize: 6,
     minTurnLength: 60,
     maxTurnLength: 300,
+    minTurnLimit: 1,
+    maxTurnLimit: 5,
   }
 
   render() {
     const { GameStore } = this.props;
-    const { playerOne, playerTwo, fieldSize, turnLength } = GameStore;
+    const { playerOne, playerTwo, fieldSize, turnLength, aiTurnLimit } = GameStore;
     const turnLengthMinutes = turnLength / 60;
 
     return (
@@ -72,6 +74,17 @@ const SettingsScreen = inject('GameStore')(observer(class SettingsScreen extends
             step={60}
             value={turnLength}
             onValueChange={(v) => GameStore.setTurnLength(v)}
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text>A.I. turn limit ({aiTurnLimit}s):</Text>
+          <Slider
+            minimumValue={this.LIMITS['minTurnLimit']}
+            maximumValue={this.LIMITS['maxTurnLimit']}
+            step={1}
+            value={aiTurnLimit}
+            onValueChange={(v) => GameStore.setTurnLimit(v)}
           />
         </View>
       </View>

--- a/stores/GameStore.js
+++ b/stores/GameStore.js
@@ -118,7 +118,8 @@ class GameStore {
 
   _turnAI() {
     InteractionManager.runAfterInteractions(() => {
-      const guess = this.ai.findWord(this.cells, this.usedWords);
+      const guess = this.ai.findWord(this.cells, this.aiTurnLimit, this.usedWords);
+
       if (guess) {
         const { index, character, words } = guess;
         this.selectedCells[index] = 1;

--- a/stores/GameStore.js
+++ b/stores/GameStore.js
@@ -19,6 +19,7 @@ class GameStore {
   players = {};
   secondsRemaining = 0;
   moves = [];
+  aiTurnLimit = 4; // seconds
   showPromptDialog = false;
   showWinnerDialog = false;
   showAITurnDialog = false;
@@ -239,6 +240,10 @@ class GameStore {
     this.turnLength = newLength;
   }
 
+  setTurnLimit(newLimit) {
+    this.aiTurnLimit = newLimit;
+  }
+
   setPlayerOneName(newName) {
     this.players['A'].name = newName;
   }
@@ -312,6 +317,7 @@ decorate(GameStore, {
   players: observable,
   secondsRemaining: observable,
   moves: observable,
+  aiTurnLimit: observable,
   showPromptDialog: observable,
   showWinnerDialog: observable,
   usedWords: computed,
@@ -329,6 +335,7 @@ decorate(GameStore, {
   openAITurnDialog: action,
   setFieldSize: action,
   setTurnLength: action,
+  setTurnLimit: action,
   setPlayerOneName: action,
   setPlayerTwoName: action,
 });


### PR DESCRIPTION
We want to limit computer's turn duration to make UI more responsive. We decided to skip further iterations over available characters to find words with them if limit is reached.

Limit can be configured via Settings, by default it equals 4 seconds.